### PR TITLE
@wirlaa/hide instead of remove

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,7 +1,7 @@
 from src.main import draw_maps, draw_maps_editor
 
 import time
-draw_maps_editor("data/size-7/mds_katz_cen_2d.csv", None)
+draw_maps_editor("data/kk_swap_2d.csv", None)
 
 # s = time.time()
 # draw_maps("data/size-7/mds_katz_cen_2d.csv", "pngs/size-7/mds_katz_cen_2d_daq", config_id='iterative')

--- a/src/editor/artists.py
+++ b/src/editor/artists.py
@@ -145,6 +145,16 @@ class ArrowArtist(Line2D, StateLinker):
 
         # delete arrow from state
         self.state.delete_arrow(self.parent_label.id, self.id)
+
+    def hide(self) -> None:
+        self.set_visible(False)
+        # disables picking by decreasing radius
+        self.set_picker(0)
+
+    def show(self) -> None:
+        self.set_visible(True)
+        # enables picking by increasing radius
+        self.set_picker(5)
         
     @staticmethod
     def arrow(ax: Axes, *args, **kwargs) -> 'ArrowArtist':
@@ -281,6 +291,14 @@ class LabelArtist(Text, StateLinker):
         dict_cpy = list(self.arrows.values()).copy()
         for arrow in dict_cpy:
             arrow.remove()
+
+    def hide(self) -> None:
+        self.set_visible(False)
+        self.set_picker(None)
+
+    def show(self) -> None:
+        self.set_visible(True)
+        self.set_picker(True)
     
     @staticmethod
     def text(ax: Axes, sid: int, **kwargs) -> 'LabelArtist':
@@ -376,6 +394,18 @@ class HullArtist(StateLinker):
         self.state.delete_hull(self.id)
 
     @staticmethod
+    def hide_hulls(ax: Axes) -> None:
+        for child in ax.get_children():
+            if type(child) is LineCollection:
+                child.set_visible(False)
+
+    @staticmethod
+    def show_hulls(ax: Axes) -> None:
+        for child in ax.get_children():
+            if type(child) is LineCollection:
+                child.set_visible(True)
+
+    @staticmethod
     def hull(ax: Axes, sid: str, **kwargs) -> 'HullArtist':
         h = HullArtist(ax, sid)
         ax.add_collection(LineCollection(segments=h.polygon_lines, colors='black'))
@@ -412,6 +442,14 @@ class PointArtist(Circle, StateLinker):
     def remove(self) -> None:
         super().remove()
 
+    def hide(self) -> None:
+        self.set_visible(False)
+        self.set_picker(None)
+
+    def show(self) -> None:
+        self.set_visible(True)
+        self.set_picker(True)
+
     @staticmethod
     def point(ax: Axes, sid: int, **kwargs) -> 'PointArtist':
         circle = PointArtist(ax, sid, **kwargs)
@@ -433,8 +471,27 @@ class PointArtist(Circle, StateLinker):
             if isinstance(child, PointArtist):
                 yield child
 
-# ------------------------------ DRAW DEFINITION ----------------------------- #
+# ----------------------------------- UTIL ---------------------------------- #
 
+def hide_labels_and_hulls(self, ax: Axes):
+    HullArtist.hide_hulls(ax)
+    for arrow in ArrowArtist.get_all_arrows(ax):
+        arrow.hide()
+    for label in LabelArtist.get_all_labels(ax):
+        label.hide()
+
+State.hide_labels_and_hulls = hide_labels_and_hulls
+
+def show_labels_and_hulls(self, ax: Axes):
+    HullArtist.show_hulls(ax)
+    for arrow in ArrowArtist.get_all_arrows(ax):
+        arrow.show()
+    for label in LabelArtist.get_all_labels(ax):
+        label.show()
+
+State.show_labels_and_hulls = show_labels_and_hulls
+
+# ------------------------------ DRAW DEFINITION ----------------------------- #
 
 def draw(self, ax: Axes) -> None:
     # clear ax
@@ -477,12 +534,11 @@ def draw(self, ax: Axes) -> None:
     ax.bbox._bbox.x1 = 0.99
     ax.bbox._bbox.y1 = 0.99
 
-    ax.set_xlim((-190, 190))
-    ax.set_ylim((-150, 150))
+    ax.set_xlim(-190, 190)
+    ax.set_ylim(-150, 150)
 
     plt.draw()
     logging.info(f"State redraw")
-    # todo check why state redraws three times while launching
 
 
 State.draw = draw

--- a/src/editor/state.py
+++ b/src/editor/state.py
@@ -108,6 +108,12 @@ class State:
         """This function should be overriten later after initialization of artists"""
         raise NotImplementedError
 
+    def hide_labels_and_hulls(self, ax: Axes):
+        raise NotImplementedError
+
+    def show_labels_and_hulls(self, ax: Axes):
+        raise NotImplementedError
+
     # ---------------------------------- GETTERS --------------------------------- #
 
     @KeyErrorWrap("")

--- a/src/editor/view_manager.py
+++ b/src/editor/view_manager.py
@@ -357,14 +357,22 @@ class View(ABC, StateLinker):
         self.vem.show()
 
     @abstractmethod
-    def undraw(self) -> None:
+    def hide(self) -> None:
         """
-        Undraws the view.
+        Hides the view.
         """
-        logging.info(f"{self.__class__} is undrawing.")
+        logging.info(f"{self.__class__} is hiding.")
         self.vem.hide()
-        # self.vem.deconstruct()
-        # self.cem.disconnect()
+        self.cem.disconnect()
+        self.vm.fig.canvas.flush_events()
+
+    def remove(self) -> None:
+        """
+        Fully deconstructs the view. Used to be called "undraw"
+        """
+        logging.info(f"{self.__class__} is removed.")
+        self.cem.disconnect()
+        self.vem.deconstruct()
         self.vm.fig.canvas.flush_events()
 
     def change_view(self, view_id: ViewsEnum, *args, **kwargs):
@@ -382,7 +390,7 @@ class View(ABC, StateLinker):
         """
         import time
         s = time.time()
-        self.undraw()
+        self.hide()
         self.vm.get_view(view_id).draw(*args, **kwargs)
         e = time.time()
         print(f"{e-s}s")

--- a/src/generator/data_processing.py
+++ b/src/generator/data_processing.py
@@ -160,7 +160,7 @@ def _parse_csv(path: str, delim=';') -> dict:
         
     """
 
-    df  = pd.read_csv(path, sep=delim)
+    df  = pd.read_csv(path, sep=delim, engine='python')
     ids = df.columns[0]
 
     df[ids] = df[ids].apply(lambda x: x.split(sep="_")[0])

--- a/src/main.py
+++ b/src/main.py
@@ -17,6 +17,9 @@ from .editor.views import parse_solution_to_editor, Editor
 from .generator.labels_generator import calc
 from .generator.hull_generator import calc_hull, parse_solution_to_editor_hull, set_hull_parameters
 
+# disabling excessive Pillow logging
+logging.getLogger('PIL').setLevel(logging.WARNING)
+
 
 def draw_maps(raw_data: Union[str, Experiment],
               out_path: str | None, delim=';',


### PR DESCRIPTION
Summary:
- hide and show functionality
- refactored clustering views

Details:
- added hide and show methods to artists
- added hide/show_hulls methods to HullArtist as a **temporary** solution 
- added general util for hiding/showing labels and hulls to state
- View now has both hide (new func) and remove (old undraw) methods
- added ax lim changes to all views to keep them consistent
- added hiding/showing labels and hulls to all views to keep them consistent
- heavily refactored all views connected to Clusters (also created a base class for different algorithms)

Other:

- added engine to pd.read_csv to disable warnings
- disabled excessive logging for Pillow in main.py
- set editor to kk_swap_2d in the example.py

